### PR TITLE
Add Micronaut catalog aliases and shared page models

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,11 @@
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+
+val commonRepositories: RepositoryHandler.() -> Unit = {
+    maven("https://mirrors.huaweicloud.com/repository/maven/")
+    mavenCentral()
+    google()
+}
+
 allprojects {
-    repositories {
-        maven("https://mirrors.huaweicloud.com/repository/maven/")
-        mavenCentral()
-        google()
-    }
+    repositories(commonRepositories)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,5 +33,10 @@ koin-ktor = { group = "io.insert-koin", name = "koin-ktor", version.ref = "koin"
 logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback" }
 
 # Micronaut 框架
+micronaut-core = { group = "io.micronaut", name = "micronaut-core", version.ref = "micronaut" }
 micronaut-http-client = { group = "io.micronaut", name = "micronaut-http-client", version.ref = "micronaut" }
 micronaut-http = { group = "io.micronaut", name = "micronaut-http", version.ref = "micronaut" }
+micronaut-logging = { group = "io.micronaut", name = "micronaut-logging", version.ref = "micronaut" }
+micronaut-validation = { group = "io.micronaut.validation", name = "micronaut-validation", version.ref = "micronaut" }
+micronaut-validation-annotations = { group = "io.micronaut.validation", name = "micronaut-validation-annotations", version.ref = "micronaut" }
+micronaut-test-junit5 = { group = "io.micronaut.test", name = "micronaut-test-junit5", version.ref = "micronaut" }

--- a/kot-framework/kot-common-model/build.gradle.kts
+++ b/kot-framework/kot-common-model/build.gradle.kts
@@ -17,6 +17,9 @@ group = "com.whitesprite.dev"
 
 dependencies {
     // Micronaut
+    api(libs.micronaut.core)
+    api(libs.micronaut.validation)
+    api(libs.micronaut.validation.annotations)
     implementation(libs.micronaut.http.client)
     implementation(libs.micronaut.http)
 }

--- a/kot-framework/kot-common-model/src/main/kotlin/com/whitesprite/dev/framework/common/poko/PageModels.kt
+++ b/kot-framework/kot-common-model/src/main/kotlin/com/whitesprite/dev/framework/common/poko/PageModels.kt
@@ -1,0 +1,29 @@
+package com.whitesprite.dev.framework.common.poko
+
+data class PageParam(
+    val page: Int = 1,
+    val size: Int = 10
+)
+
+data class SortingField(
+    val field: String,
+    val direction: SortDirection = SortDirection.ASC
+)
+
+enum class SortDirection {
+    ASC,
+    DESC
+}
+
+data class SortablePageParam(
+    val page: Int = 1,
+    val size: Int = 10,
+    val sorting: List<SortingField> = emptyList()
+)
+
+data class PageResult<T>(
+    val page: Int,
+    val size: Int,
+    val total: Long,
+    val records: List<T>
+)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.initialization.resolve.RepositoriesMode
+
 rootProject.name = "kot-cloud"
 
 // Framework modules
@@ -17,5 +19,21 @@ include(
 pluginManagement {
     repositories {
         maven("https://mirrors.huaweicloud.com/repository/maven/")
+        mavenCentral()
+        google()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        maven("https://mirrors.huaweicloud.com/repository/maven/")
+        mavenCentral()
+        google()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("gradle/libs.versions.toml"))
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add Micronaut core, validation, logging, and test entries to the version catalog
- centralize repository configuration with dependency resolution management and shared helper
- introduce common paging DTOs and export Micronaut annotation/validation dependencies as api

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942d0211de48328bf065f30e17e6262)