### PR TITLE
refactor(build): 更新项目构建配置以使用KSP替代KAPT

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.
 # Micronaut 框架
 micronaut-core = { group = "io.micronaut", name = "micronaut-core", version.ref = "micronaut" }
 micronaut-runtime = { group = "io.micronaut", name = "micronaut-runtime", version.ref = "micronaut" }
-micronaut-inject = { group = "io.micronaut", name = "micronaut-inject", version.ref = "micronaut" }
+micronaut-inject-kotlin = { group = "io.micronaut", name = "micronaut-inject-kotlin", version.ref = "micronaut" }
 micronaut-http-client = { group = "io.micronaut", name = "micronaut-http-client", version.ref = "micronaut" }
 micronaut-http = { group = "io.micronaut", name = "micronaut-http", version.ref = "micronaut" }
 micronaut-http-server-netty = { group = "io.micronaut", name = "micronaut-http-server-netty", version.ref = "micronaut" }

--- a/kot-module-system/kot-module-system-server/build.gradle.kts
+++ b/kot-module-system/kot-module-system-server/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("jvm")
-    kotlin("kapt")
+    id("com.google.devtools.ksp")
 }
 
 group = "com.whitesprite.dev"
@@ -50,7 +50,7 @@ dependencies {
     api(libs.micronaut.data.tx)
 
     // Micronaut Data Processor
-    kapt(libs.micronaut.data.processor)
+    ksp(libs.micronaut.data.processor)
 
     // Micronaut Jackson
     api(libs.micronaut.jackson)
@@ -63,7 +63,7 @@ dependencies {
     runtimeOnly(libs.postgresql)
 
     // Micronaut 注解处理器
-//    kapt(libs.micronaut.inject.java)
+    ksp(libs.micronaut.inject.kotlin)
 
     // system-api 模块
     api(project(":kot-module-system:kot-module-system-api"))

--- a/kot-module-system/kot-module-system-server/src/main/kotlin/com/whitesprite/dev/module/system/domain/user/gateway/AdminUserGateway.kt
+++ b/kot-module-system/kot-module-system-server/src/main/kotlin/com/whitesprite/dev/module/system/domain/user/gateway/AdminUserGateway.kt
@@ -4,19 +4,52 @@ import com.whitesprite.dev.module.system.infrastructure.persistence.entity.user.
 import java.util.Optional
 
 interface AdminUserGateway {
+    /**
+     * 确认用户名是否存在
+     * @param name 用户名
+     * @return 用户名是否存在的结果
+     */
     fun existsByUsername(name: String): Boolean
 
+    /**
+     * 保存用户信息
+     * @param entity 用户信息
+     * @return 保存后的用户信息
+     */
     fun save(entity: AdminUserEntity): AdminUserEntity
 
+    /**
+     * 确认用户ID是否存在
+     * @param id 用户ID
+     * @return 用户ID是否存在的结果
+     */
     fun existsById(id: Long): Boolean
 
+    /**
+     * 删除用户信息
+     * @param id 用户ID
+     */
     fun deleteById(id: Long)
 
+    /**
+     * 查询用户信息
+     * @param id 用户ID
+     * @return 用户信息
+     */
     fun findById(id: Long): Optional<AdminUserEntity>
 
+    /**
+     * 更新用户信息
+     */
     fun update(entity: AdminUserEntity): AdminUserEntity
 
+    /**
+     * 查询所有用户信息
+     */
     fun findAll(): List<AdminUserEntity>
 
+    /**
+     * 根据昵称模糊查询用户信息
+     */
     fun findByNicknameIlike(name: String): List<AdminUserEntity>
 }

--- a/kot-server/build.gradle.kts
+++ b/kot-server/build.gradle.kts
@@ -12,8 +12,8 @@ dependencies {
     // Micronaut HTTP
     implementation(libs.micronaut.http.server.netty)
     // Micronaut Data Processor
-//    kapt(libs.micronaut.data.processor)
-    ksp(libs.micronaut.inject)
+    ksp(libs.micronaut.data.processor)
+    ksp(libs.micronaut.inject.kotlin)
     // SLF4J 相关
     runtimeOnly(libs.logback.classic)
     // Micronaut Jackson

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,7 +33,6 @@ pluginManagement {
     }
     plugins {
         kotlin("jvm") version "2.3.0"
-        kotlin("kapt") version "2.3.0"
         id("com.google.devtools.ksp") version "2.3.4"
     }
 }


### PR DESCRIPTION
- 将kotlin("kapt")插件替换为com.google.devtools.ksp插件
- 修改注解处理器依赖从kapt改为ksp
- 更新micronaut注入相关依赖为Kotlin版本
- 移除不再需要的KAPT插件配置
- 为AdminUserGateway接口添加完整的KDoc文档注释

TODO:该提交存在Micronaut注解器问题，请留存该提交到独立分支